### PR TITLE
Disable line gutter in minimap

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1489,6 +1489,7 @@ impl EditorElement {
         };
 
         editor.mode = EditorMode::Minimap;
+        editor.show_gutter = false;
         editor.set_text_style_refinement(TextStyleRefinement {
             font_size: Some(px(minimap_settings.font_size).into()),
             font_weight: Some(gpui::FontWeight(900.)),


### PR DESCRIPTION
This disables the gutter on the left side of the minimap, which was especially visible for larger minimap font sizes. With this disabled, more text is visible in the minimap. 

However, the invisible gutter added some padding to the left side of the minimap which now is no longer there. We might have to add some padding some other way, since this changes it from too much padding to no padding.